### PR TITLE
Add onDonationRequest dependency for ChariotConnect

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -49,7 +49,7 @@ const ChariotConnect: React.FC<ChariotConnectProps> = ({
             document.body.removeChild(script);
             connectContainer?.removeChild(connect);
         }
-    }, []);
+    }, [onDonationRequest]);
 
     return (
         <div id="connectContainer">


### PR DESCRIPTION
Before:
ChariotConnect would only load data from `onDonationRequest` function on initial page load. User would have to use `useRef` to create references to data so that data was always up to date for `ChariotConnect`

After:
ChariotConnect component has `onDonationRequest` as a dependency so listeners and elements are regenerated whenever underlying data updates.